### PR TITLE
Add Flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
-# To get nix and set up the binary cache
+# Notice (DEPRECATED)
 
-Follow the instructions [here](https://app.cachix.org/cache/mjlbach) to set up nix and add my cachix cache which provides precompiled binaries, built against the nixos-unstable channel each night.
-
-# To use the overlay
-
-Add the following to your $HOME/.config/nixpkgs/overlays directory: (make a file $HOME/.config/nixpkgs/overlays/emacs.nix and paste the snippet below into that file)
-
-```nix
-import (builtins.fetchTarball {
-      url = https://github.com/mjlbach/emacs-pgtk-nativecomp-overlay/archive/master.tar.gz;
-    })
-```
-
-Install emacsGccPgtk:
-```
-nix-env -iA nixpkgs.emacsGccPgtk
-```
-or add to home-manager/configuration.nix.
-
-Note:
-
-Emacs no longer needs to be wrapped to find the appropriate libgccjit libraries, as such emacsGccPgtkWrapped was removed.
+Use the [nix-community emacs-overlay](https://github.com/nix-community/emacs-overlay).  
+Emacs pgtk with native comp has been merged as of this [commit](https://github.com/nix-community/emacs-overlay/commit/4629eb4142029522703cd8ee3247397ae038d047).

--- a/build.nix
+++ b/build.nix
@@ -1,9 +1,9 @@
 let
   sources = import ./nix/sources.nix;
-  nixpkgs = sources."nixos-unstable";
-  emacs-pgtk-overlay = import ./default.nix;
-  pkgs = import nixpkgs { config = {}; overlays = [ emacs-pgtk-overlay ]; };
+  nixpkgs = sources.nixos-unstable;
+  emacs-pgtk-overlay = import ./overlay.nix;
+  pkgs = import nixpkgs { config = { }; overlays = [ emacs-pgtk-overlay ]; };
 in
 {
-  emacsGccPgtk = pkgs.emacsGccPgtk;
+  inherit (pkgs) emacsGccPgtk;
 }

--- a/default.nix
+++ b/default.nix
@@ -2,13 +2,13 @@
 , sources ? import ./nix/sources.nix
 , pkgs ? import sources.nixos-unstable {}
 , stdenv ? pkgs.stdenv
-, lib ? pkgs.lib
 , emacs-pgtk-nativecomp ? sources.emacs-pgtk-nativecomp
 , emacs ? pkgs.emacs
 , fetchpatch ? pkgs.fetchpatch
 , fetchFromGitHub ? pkgs.fetchFromGitHub
 }:
 
+with stdenv.lib;
 let
   emacsGccPgtk = builtins.foldl' (drv: fn: fn drv)
     emacs

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "emacs-pgtk-nativecomp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1602200331,
+        "narHash": "sha256-+5aQKcWEV9l1Rf71ejnkI9ZFyr0kvKR8sJacc72IXYc=",
+        "owner": "flatwhatson",
+        "repo": "emacs",
+        "rev": "920d458ab5971c8729f26449926b0436a72138ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "flatwhatson",
+        "ref": "pgtk-nativecomp",
+        "repo": "emacs",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1602066138,
+        "narHash": "sha256-aV0PWKhVYQNLQuFW2qfBXa3JWmPPKSHFJ65ac83JMzE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "420f89ceb267b461eed5d025b6c3c0e57703cc5c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "emacs-pgtk-nativecomp": "emacs-pgtk-nativecomp",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "Emacs with native compilation and pgtk";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.emacs-pgtk-nativecomp = { url = "github:flatwhatson/emacs/pgtk-nativecomp"; flake = false; };
+
+  outputs = { self, flake-utils, emacs-pgtk-nativecomp, nixpkgs }:
+    (flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      src = pkgs.callPackage ./default.nix { inherit emacs-pgtk-nativecomp; };
+    in rec {
+      inherit (src) packages;
+      legacyPackages = packages;
+      defaultPackage = packages.emacsGccPgtk;
+    }))
+    // {
+      overlay = import ./overlay.nix;
+    };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,2 @@
+final: prev:
+(prev.callPackage ./default.nix { }).packages

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,2 +1,5 @@
 final: prev:
-(prev.callPackage ./default.nix { }).packages
+let packages = (prev.callPackage ./default.nix { }).packages;
+in {
+  inherit (packages) emacsGccPgtk;
+}


### PR DESCRIPTION
This PR adds support for building the project with Flakes. Niv can be entirely replaced with Flakes and the `default.nix` could be made to use [flake-compat](https://github.com/edolstra/flake-compat) to allow non-flake systems to build this project.

If you don't have Nix Flakes, you can quickly test this PR with the following steps:
1. `nix-shell -p nixFlakes`
2. `echo "experimental-features = nix-command flakes" >> $HOME/.config/nix/nix.conf`

I confirmed that both Flake and non-Flake builds worked correctly:
- `nix-build -A packages.emacsGccPgtk`
- `nix build -vL` or `nix build -vL '.#emacsGccPgtk'` (with `-v` and `-L` being options to have a more verbose output)

The workflow to update inputs is different from Niv.

**To update all dependencies**
``` console
$ nix flake update --recreate-lock-file
```

**To update one or more dependencies**
``` console
$ nix flake update --update-input nixpkgs --update-input emacs-gcc-pgtk
```

There are two things left to be done before merging this PR:
- [ ] Removing Niv and using `flake-compat`
- [ ] Adding a Github Actions workflow to update inputs