### PR TITLE
Set pname instead of name in derivations

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 let
   sources = import ./nix/sources.nix;
   nixpkgs = sources."nixos-unstable";
-  pkgs = import nixpkgs {};
+  pkgs = import nixpkgs { };
   emacs-pgtk-nativecomp = sources."emacs-pgtk-nativecomp";
   emacs-nativecomp = sources."emacs-nativecomp";
   mkGitEmacs = attrs: builtins.foldl' (drv: fn: fn drv)
@@ -9,29 +9,32 @@ let
     [
 
       (drv: drv.override { srcRepo = true; })
-       (
-          drv:
-          if attrs.usePgtk then drv.overrideAttrs (
-            old: {
-              name = "emacsGccPgtk";
-              version = "28.0.50";
-              src = pkgs.fetchFromGitHub {
-                inherit (emacs-pgtk-nativecomp) owner repo rev sha256;
-              };
+      (
+        drv:
+        if attrs.usePgtk then
+          drv.overrideAttrs
+            (
+              old: {
+                pname = "emacsGccPgtk";
+                version = "28.0.50";
+                src = pkgs.fetchFromGitHub {
+                  inherit (emacs-pgtk-nativecomp) owner repo rev sha256;
+                };
 
-              configureFlags = old.configureFlags
-              ++ [ "--with-pgtk" ];
-            }
-          ) else drv.overrideAttrs (
-            old: {
-              name = "emacsGcc";
+                configureFlags = old.configureFlags
+                  ++ [ "--with-pgtk" ];
+              }
+            ) else
+          drv.overrideAttrs (
+            _old: {
+              pname = "emacsGcc";
               version = "28.0.50";
               src = pkgs.fetchFromGitHub {
                 inherit (emacs-nativecomp) owner repo rev sha256;
               };
             }
-        )
-        )
+          )
+      )
 
       (
         drv: drv.overrideAttrs (
@@ -73,7 +76,7 @@ _: _:
 {
   ci = (import ./nix { }).ci;
 
-    emacsGccPgtk = (mkGitEmacs {usePgtk = true;});
-    emacsGcc = (mkGitEmacs {usePgtk = false;});
+  emacsGccPgtk = (mkGitEmacs { usePgtk = true; });
+  emacsGcc = (mkGitEmacs { usePgtk = false; });
 
-  }
+}


### PR DESCRIPTION
The version is thus preserved in the derivation name.
This is required by functions like `lib.getVersion` (which is used by home-manager for its emacs module to enable socket activation).

This commit also formats the code because of the precommit linter in the `shell.nix`.